### PR TITLE
Fix search query validation for biblical references

### DIFF
--- a/src/wol/utils.ts
+++ b/src/wol/utils.ts
@@ -127,7 +127,7 @@ export class SearchOperatorParser {
   // Validate search operators syntax
   static validateOperators(query: string): boolean {
     // Allow unicode letters/numbers so non-English queries pass validation
-    const validOperators = /^[\p{L}\p{N}\s&+|\/\^%!"\*\?#\\()_-]+$/u;
+    const validOperators = /^[\p{L}\p{N}\s&+|\/\^%!"\*\?#\\()_\-\.:]+$/u;
     return validOperators.test(query);
   }
 


### PR DESCRIPTION
Allow periods and colons in search queries to support Bible text notation and verse ranges.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d9cd78a-fa19-4e53-a888-ff87826f378d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d9cd78a-fa19-4e53-a888-ff87826f378d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

